### PR TITLE
convert types for conf set via env var

### DIFF
--- a/dremio_client/conf/config_parser.py
+++ b/dremio_client/conf/config_parser.py
@@ -32,6 +32,10 @@ def _get_env_args():
     for k, v in os.environ.items():
         if "DREMIO_" in k and k != "DREMIO_CLIENTDIR":
             name = k.replace("DREMIO_", "").lower().replace("_", ".")
+            if name == "port":
+              v = int(v)
+            elif name=="ssl":
+              v = v.lower() in ['true', '1', 't', 'y', 'yes', 'yeah', 'yup', 'certainly', 'uh-huh']
             args[name] = v
     return args
 


### PR DESCRIPTION
to avoid errors like:

confuse.ConfigTypeError: port: must be a number
or
confuse.ConfigTypeError: ssl: must be a bool, not str

