### PR TITLE
add response to error bad request exception

### DIFF
--- a/dremio_client/error.py
+++ b/dremio_client/error.py
@@ -29,9 +29,10 @@ class DremioException(Exception):
     base dremio exception
     """
 
-    def __init__(self, msg, original_exception):
+    def __init__(self, msg, original_exception, response=None):
         super(DremioException, self).__init__(msg + (": %s" % original_exception))
         self.original_exception = original_exception
+        self.response = response
 
 
 class DremioUnauthorizedException(DremioException):
@@ -47,7 +48,4 @@ class DremioNotFoundException(DremioException):
 
 
 class DremioBadRequestException(DremioException):
-    def __init__(self, msg, original_exception, response):
-        DremioException.__init__(self,msg, original_exception)
-        self.response = response
     pass

--- a/dremio_client/error.py
+++ b/dremio_client/error.py
@@ -47,4 +47,7 @@ class DremioNotFoundException(DremioException):
 
 
 class DremioBadRequestException(DremioException):
+    def __init__(self, msg, original_exception, response):
+        DremioException.__init__(self,msg, original_exception)
+        self.response = response
     pass

--- a/dremio_client/model/endpoints.py
+++ b/dremio_client/model/endpoints.py
@@ -76,11 +76,11 @@ def _check_error(r, details=""):
     if code == 400:
         raise DremioBadRequestException("Requested object does not exist on entity " + details, error, r)
     if code == 401:
-        raise DremioUnauthorizedException("Unauthorized on api endpoint " + details, error)
+        raise DremioUnauthorizedException("Unauthorized on api endpoint " + details, error, r)
     if code == 403:
-        raise DremioPermissionException("Not permissioned to view entity at " + details, error)
+        raise DremioPermissionException("Not permissioned to view entity at " + details, error, r)
     if code == 404:
-        raise DremioNotFoundException("No entity exists at " + details, error)
+        raise DremioNotFoundException("No entity exists at " + details, error, r)
     raise DremioException("unknown error", error)
 
 

--- a/dremio_client/model/endpoints.py
+++ b/dremio_client/model/endpoints.py
@@ -74,7 +74,7 @@ def _check_error(r, details=""):
         except:  # NOQA
             return r.text
     if code == 400:
-        raise DremioBadRequestException("Requested object does not exist on entity " + details, error)
+        raise DremioBadRequestException("Requested object does not exist on entity " + details, error, r)
     if code == 401:
         raise DremioUnauthorizedException("Unauthorized on api endpoint " + details, error)
     if code == 403:


### PR DESCRIPTION
As a client application, I'm very frustrated when I encounter a "Bad Request exception" because it does not tell me what was the problem.
What do you thing of including the HTTP response body as a attribute of the exception, so that a client have all the details when that happens ?

```
      except DremioBadRequestException as e:
        print(str(e.response.json()['errorMessage']))
        pass
```