### PR TITLE
graph in the data model

### DIFF
--- a/dremio_client/model/data.py
+++ b/dremio_client/model/data.py
@@ -31,6 +31,7 @@ from ..error import DremioException
 from ..util import refresh_metadata
 from .endpoints import (
     catalog_item,
+    graph,
     collaboration_tags,
     collaboration_wiki,
     delete_catalog,
@@ -742,6 +743,12 @@ class Dataset(Catalog):
             approximateStatisticsAllowed=kwargs.get("approximateStatisticsAllowed"),
             accessControlList=_get_acls(kwargs.get("accessControlList")),
         )
+
+    def get_graph(self):
+        try:
+            return graph(self._token, self._base_url, self.meta.id, ssl_verify=self._ssl_verify)
+        except Exception:  # NOQA
+            return graph(self._token, self._base_url, path=self.meta.path, ssl_verify=self._ssl_verify)
 
     def get_table(self):
         return '.'.join('"{0}"'.format(w) for w in self.meta.path)


### PR DESCRIPTION
I understand that the graph endpoint is only usable by the client, and I mostly use the python module in scripts, so this is just a quick and dirty way to get the graph information in the python module.

```
from dremio_client import init
catalog = init().data
catalog.SPACENAME.VDS1.get_graph()

{'sources': [{'id': '9920ddc6-7796-4f47-b697-d05b14e2e842',
   'path': ['INFORMATION_SCHEMA'],
   'tag': '6UIelxay0Ao=',
   'type': 'CONTAINER',
   'containerType': 'SOURCE'}],
 'parents': [{'id': '35ac58ad-5579-4b6e-ba3b-e1b08fbfcbea',
   'path': ['SPACENAME2', 'FOLDER1', 'DATASET2'],
   'tag': '/IJ4Au31kqQ=',
   'type': 'DATASET',
   'datasetType': 'VIRTUAL'}],
 'children': []}
```

