### PR TITLE
Fixed a small bug where -p is used for the port and the password.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ ENV/
 .mypy_cache/
 
 .idea
+
+.vscode

--- a/docs/command_line_interface.rst
+++ b/docs/command_line_interface.rst
@@ -15,10 +15,10 @@ All of the REST API calls are exposed via the command line interface. To see a l
         Options:
           --config DIRECTORY   Custom config file.
           -h, --hostname TEXT  Hostname if different from config file
-          -pt, --port INTEGER  Hostname if different from config file
+          -p, --port INTEGER  Hostname if different from config file
           --ssl                Use SSL if different from config file
           -u, --username TEXT  username if different from config file
-          -p, --password TEXT  password if different from config file
+          -P, --password TEXT  password if different from config file
           --help               Show this message and exit.
 
         Commands:

--- a/docs/command_line_interface.rst
+++ b/docs/command_line_interface.rst
@@ -15,7 +15,7 @@ All of the REST API calls are exposed via the command line interface. To see a l
         Options:
           --config DIRECTORY   Custom config file.
           -h, --hostname TEXT  Hostname if different from config file
-          -p, --port INTEGER   Hostname if different from config file
+          -pt, --port INTEGER  Hostname if different from config file
           --ssl                Use SSL if different from config file
           -u, --username TEXT  username if different from config file
           -p, --password TEXT  password if different from config file

--- a/dremio_client/cli.py
+++ b/dremio_client/cli.py
@@ -80,7 +80,7 @@ def print_version(ctx, param, value):
 @click.group()
 @click.option("--config", type=click.Path(exists=True, dir_okay=True, file_okay=False), help="Custom config file.")
 @click.option("-h", "--hostname", help="Hostname if different from config file")
-@click.option("-p", "--port", type=int, help="Hostname if different from config file")
+@click.option("-pt", "--port", type=int, help="Hostname if different from config file")
 @click.option("--ssl", is_flag=True, help="Use SSL if different from config file")
 @click.option("-u", "--username", help="username if different from config file")
 @click.option("-p", "--password", help="password if different from config file")

--- a/dremio_client/cli.py
+++ b/dremio_client/cli.py
@@ -80,10 +80,10 @@ def print_version(ctx, param, value):
 @click.group()
 @click.option("--config", type=click.Path(exists=True, dir_okay=True, file_okay=False), help="Custom config file.")
 @click.option("-h", "--hostname", help="Hostname if different from config file")
-@click.option("-pt", "--port", type=int, help="Hostname if different from config file")
+@click.option("-p", "--port", type=int, help="Hostname if different from config file")
 @click.option("--ssl", is_flag=True, help="Use SSL if different from config file")
 @click.option("-u", "--username", help="username if different from config file")
-@click.option("-p", "--password", help="password if different from config file")
+@click.option("-P", "--password", help="password if different from config file")
 @click.option("--skip-verify", is_flag=True, help="skip verificatoin of ssl cert")
 @click.option("--version", is_flag=True, callback=print_version, expose_value=False, is_eager=True)
 @click.pass_context


### PR DESCRIPTION
Fixed a small bug where `-p` is used for the port and the password at the global command line options.

The behaviour was that only the password was filled in the argument of the cli function.