### PR TITLE
Documenting the configuration of the Dremio client using the config.yaml file.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,6 +36,42 @@ The relevant configs can also be set via environment variables. These take prece
 to append ``DREMIO_`` to a config parameter and nested configs are separated by a *_*. For example:
 ``DREMIO_AUTH_TIMEOUT`` maps to ``auth.timeout`` in the default configuration file above.
 
+You can download the default example `config.yaml`_ from the repository.
+
+Follow these steps to setup the configuration file.
+
+    .. code-block:: bash
+
+        $ mkdir -p ~/.config/dremio_client
+        $ wget -O ~/.config/dremio_client/config.yaml https://raw.githubusercontent.com/rymurr/dremio_client/master/dremio_client/conf/config_default.yaml
+
+Once the file is in the directory, please edit the file with the appropriate information.
+
+Autocompletion
+--------------
+
+To activate the autocompletion for ``bash`` or ``zsh``, append the following line to the appropriate configuration file.
+
+zsh
+^^^
+
+Configuration file name ``~/.zshrc``.
+
+    .. code-block:: bash
+
+        # Enable dremio_client autocomplete
+        eval "$(_DREMIO_CLIENT_COMPLETE=source_zsh dremio_client)"
+
+bash
+^^^^
+
+Configuration file name ``~/.bashrc``.
+
+    .. code-block:: bash
+
+        # Enable dremio_client autocomplete
+        eval "$(_DREMIO_CLIENT_COMPLETE=source_bash dremio_client)"
 
 .. _confuse: https://github.com/beetbox/confuse
 .. _command line interface: ./command_line_interface.html
+.. _config.yaml: https://github.com/rymurr/dremio_client/blob/master/dremio_client/conf/config_default.yaml


### PR DESCRIPTION
Plus the documentation of How to support the autocompletion of the Click library.
Reference: https://click.palletsprojects.com/en/7.x/bashcomplete/