### PR TITLE
pyodbc / escape special chars in password

### DIFF
--- a/dremio_client/odbc.py
+++ b/dremio_client/odbc.py
@@ -65,7 +65,7 @@ try:
         _get_driver_name()
         c = pyodbc.connect(
             "Driver={};ConnectionType=Direct;HOST={};PORT={};AuthenticationType=Plain;UID={};PWD={}".format(
-                _DRIVER, hostname, port, username, password
+                _DRIVER, hostname, port, username, "{" + password + "}"
             ),
             autocommit=True,
         )


### PR DESCRIPTION
I've seen users for which dremio_client would not work in odbc, and it appears it's because they had ";" characters in their passwords, which messes with the odbc connection string.
Apparently escaping the passwords with "{}" works. I've tried on my setup and I didn't encounter a problem.
See : https://stackoverflow.com/a/42282362