### PR TITLE
return pyarrow.Table instead of return the pandas-compatible NumPy ar…

### DIFF
--- a/dremio_client/flight/__init__.py
+++ b/dremio_client/flight/__init__.py
@@ -146,11 +146,9 @@ try:
                 batches.append(batch)
             except StopIteration:
                 break
-        data = pa.Table.from_batches(batches)
-        if pandas:
-            return data.to_pandas()
-        else:
-            return data
+        table = pa.Table.from_batches(batches)
+        
+        return table
 
 
 except ImportError:


### PR DESCRIPTION
…ray via to_pandas()

the to_pandas() is pretty expensive, if the returned data size is huge, e.g 8GB, it might cause core crush.
return the pyarrow.Table gives end user more fliexibility